### PR TITLE
control namespaces for middlewares

### DIFF
--- a/src/SocketControllerExecutor.ts
+++ b/src/SocketControllerExecutor.ts
@@ -75,7 +75,8 @@ export class SocketControllerExecutor {
             middleware.nsp instanceof RegExp
               ? middleware.nsp
               : (name: string, auth: unknown, next: (err: Error | null, success: boolean) => void) => {
-                  next(null, (middleware.nsp as string[]).indexOf(name) >= 0);
+                  const nspFilter = middleware.nsp as string[];
+                  next(null, !nspFilter.length || nspFilter.indexOf(name) >= 0);
                 }
           )
           .use((socket: any, next: (err?: any) => any) => {

--- a/src/SocketControllerExecutor.ts
+++ b/src/SocketControllerExecutor.ts
@@ -71,13 +71,13 @@ export class SocketControllerExecutor {
       .sort((middleware1, middleware2) => (middleware1.priority || 0) - (middleware2.priority || 0))
       .forEach(middleware => {
         this.io
-          .of((name: string, auth: unknown, next: (err: Error | null, success: boolean) => void) => {
-            const filterNamespace = middleware.nsp;
-            const allowMiddleware =
-              (filterNamespace instanceof RegExp && filterNamespace.test(name)) ||
-              (filterNamespace as string[]).indexOf(name) >= 0;
-            next(null, allowMiddleware);
-          })
+          .of(
+            middleware.nsp instanceof RegExp
+              ? middleware.nsp
+              : (name: string, auth: unknown, next: (err: Error | null, success: boolean) => void) => {
+                  next(null, (middleware.nsp as string[]).indexOf(name) >= 0);
+                }
+          )
           .use((socket: any, next: (err?: any) => any) => {
             middleware.instance.use(socket, next);
           });

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -226,11 +226,14 @@ export function SocketRooms() {
 /**
  * Registers a new middleware to be registered in the socket.io.
  */
-export function Middleware(options?: { priority?: number }): Function {
+export function Middleware(options?: { priority?: number; nsp?: string | RegExp | string[] }): Function {
   return function (object: Function) {
+    options = options || {};
+    const { priority, nsp } = options;
     const metadata: MiddlewareMetadataArgs = {
       target: object,
-      priority: options && options.priority ? options.priority : undefined,
+      priority,
+      nsp: nsp ? (nsp instanceof RegExp || Array.isArray(nsp) ? nsp : [nsp]) : [],
     };
     defaultMetadataArgsStorage().middlewares.push(metadata);
   };

--- a/src/metadata/MiddlewareMetadata.ts
+++ b/src/metadata/MiddlewareMetadata.ts
@@ -8,7 +8,8 @@ export class MiddlewareMetadata {
   // -------------------------------------------------------------------------
 
   target: Function;
-  priority: number;
+  priority: number | undefined;
+  nsp: RegExp | string[];
 
   // -------------------------------------------------------------------------
   // Constructor
@@ -17,6 +18,7 @@ export class MiddlewareMetadata {
   constructor(args: MiddlewareMetadataArgs) {
     this.target = args.target;
     this.priority = args.priority;
+    this.nsp = args.nsp;
   }
 
   // -------------------------------------------------------------------------

--- a/src/metadata/args/MiddlewareMetadataArgs.ts
+++ b/src/metadata/args/MiddlewareMetadataArgs.ts
@@ -8,4 +8,9 @@ export interface MiddlewareMetadataArgs {
    * Middleware priority.
    */
   priority?: number;
+
+  /**
+   * Limits usage of the middleware to the given namespaces
+   */
+  nsp: RegExp | string[];
 }


### PR DESCRIPTION
## Description
- fixes https://github.com/typestack/socket-controllers/issues/261
- solution: middlewares now have to e added per namespace, therefore I used the socket.io native .of() with a function filter
- added the possibility to limit usage of middleware by name or regular expression related to the namespace

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #261
