### PR TITLE
feat: support multiple parameters in message body

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,22 @@ export class MessageController {
 
 If you specify a class type to parameter that is decorated with `@MessageBody()`,
 socket-controllers will use [class-transformer][1] to create instance of the given class type with the data received in the message.
-To disable this behaviour you need to specify a `{ transformOption: { transform: false ] }` in SocketControllerOptions when creating a server.
+To disable this behaviour you need to specify `{ transformOption: { transform: false ] }` in SocketControllerOptions when creating a server.
+
+You can define an index to get multiple parameters from the socket event.
+
+```typescript
+import { SocketController, OnMessage, MessageBody } from 'socket-controllers';
+
+@SocketController()
+export class MessageController {
+  @OnMessage('save')
+  save(@MessageBody({index: 0}) param1: any, @MessageBody({index: 1}) param2: any) {
+    console.log('received message: ', message1);
+    console.log('received message: ', message2);
+  }
+}
+```
 
 #### `@SocketQueryParam()` decorator
 

--- a/src/SocketControllers.ts
+++ b/src/SocketControllers.ts
@@ -189,14 +189,13 @@ export class SocketControllers {
     for (const messageAction of messageActions) {
       socket.on(messageAction.options.name, (...args: any[]) => {
         const messages: any[] = args.slice(0, -1);
-        let ack: any = args[args.length - 1];
+        const ack: any = args[args.length - 1];
 
         if (!(ack instanceof Function)) {
           messages.push(ack);
-          ack = undefined;
         }
 
-        this.executeAction(socket, controller, messageAction, messages, ack as () => void);
+        this.executeAction(socket, controller, messageAction, messages);
       });
     }
   }
@@ -205,10 +204,9 @@ export class SocketControllers {
     socket: Socket,
     controller: HandlerMetadata<any, ControllerMetadata>,
     action: ActionMetadata,
-    data?: any[],
-    ack?: () => void
+    data?: any[]
   ) {
-    const parameters = this.resolveParameters(socket, controller.metadata, action.parameters || [], data, ack);
+    const parameters = this.resolveParameters(socket, controller.metadata, action.parameters || [], data);
     try {
       const actionResult = controller.instance[action.methodName](...parameters);
       Promise.resolve(actionResult)
@@ -250,8 +248,7 @@ export class SocketControllers {
     socket: Socket,
     controllerMetadata: ControllerMetadata,
     parameterMetadatas: ParameterMetadata[],
-    data?: any[],
-    ack?: () => void
+    data?: any[]
   ) {
     const parameters = [];
 

--- a/src/decorators/MessageBody.ts
+++ b/src/decorators/MessageBody.ts
@@ -2,7 +2,7 @@ import { addParameterToActionMetadata } from '../util/add-parameter-to-action-me
 import { ParameterType } from '../types/enums/ParameterType';
 import { ActionTransformOptions } from '../types/ActionTransformOptions';
 
-export function MessageBody(options?: ActionTransformOptions) {
+export function MessageBody(options?: ActionTransformOptions & { index?: number }) {
   return function (object: Object, methodName: string, index: number) {
     const format = (Reflect as any).getMetadata('design:paramtypes', object, methodName)[index];
     addParameterToActionMetadata(object.constructor, methodName, {

--- a/test/functional/socket-message-body.spec.ts
+++ b/test/functional/socket-message-body.spec.ts
@@ -62,6 +62,16 @@ describe('MessageBody', () => {
         testResult = data;
         socket.emit('return');
       }
+
+      @OnMessage('test2')
+      test2(
+        @MessageBody({ index: 1 }) data1: any,
+        @MessageBody({ index: 0 }) data0: any,
+        @ConnectedSocket() socket: Socket
+      ) {
+        testResult = { data1, data0 };
+        socket.emit('return2');
+      }
     }
 
     socketControllers = new SocketControllers({
@@ -74,8 +84,13 @@ describe('MessageBody', () => {
     await waitForEvent(wsClient, 'connected');
 
     wsClient.emit('test', 'test data');
-
     await waitForEvent(wsClient, 'return');
     expect(testResult).toEqual('test data');
+
+    wsClient.emit('test2', 'test data 0', 'test data 1', 'test data 2', ack => {
+      console.log(ack);
+    });
+    await waitForEvent(wsClient, 'return2');
+    expect(testResult).toEqual({ data0: 'test data 0', data1: 'test data 1' });
   });
 });


### PR DESCRIPTION
## Description
Add support for multiple parameters in `@MessageBody()` decorator.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #18
