### PR TITLE
feat: error specific @EmitOnFail()

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ import { SocketController, OnMessage, EmitOnSuccess, EmitOnFail } from 'socket-c
 export class MessageController {
   @OnMessage('save')
   @EmitOnSuccess('save_successfully')
+  @EmitOnFail('save_error_range', {errorType: RangeError})
+  @EmitOnFail('save_error_type', {errorType: TypeError})
   @EmitOnFail('save_error')
   save() {
     if (1 === 1) {
@@ -272,6 +274,7 @@ export class MessageController {
 ```
 
 In this case `save_error` message will be sent to the client with `One is equal to one! Fatal error!` error message.
+The order is important when defining multiple `@EmitOnFail()` decorators, the first matching errorType will be served
 
 Sometimes you may want to not emit success/error message if returned result is null or undefined.
 In such cases you can use `@SkipEmitOnEmptyResult()` decorator.

--- a/src/decorators/EmitOnFail.ts
+++ b/src/decorators/EmitOnFail.ts
@@ -2,7 +2,7 @@ import { addResultToActionMetadata } from '../util/add-result-to-action-metadata
 import { ResultType } from '../types/enums/ResultType';
 import { ActionTransformOptions } from '../types/ActionTransformOptions';
 
-export function EmitOnFail(messageName: string, options?: ActionTransformOptions): Function {
+export function EmitOnFail(messageName: string, options?: ActionTransformOptions & { errorType: unknown }): Function {
   return function (object: Object, methodName: string) {
     addResultToActionMetadata(object.constructor, methodName, {
       type: ResultType.EMIT_ON_FAIL,


### PR DESCRIPTION
## Description
Add option to define an errorType property for `@EmitOnFail()`. You can define multiple, the first matching will be used.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #53, #4
