### PR TITLE
feat: add option to dispose scoped container

### DIFF
--- a/src/types/SocketControllersOptions.ts
+++ b/src/types/SocketControllersOptions.ts
@@ -9,6 +9,8 @@ export interface SocketControllersOptions {
     get<T>(someClass: { new (...args: any[]): T } | Function): T;
   };
 
+  scopedContainerDisposer?: (container: { get<T>(someClass: { new (...args: any[]): T } | Function): T }) => void;
+
   io?: Server;
 
   port?: number;

--- a/test/functional/scoped-controllers.spec.ts
+++ b/test/functional/scoped-controllers.spec.ts
@@ -2,7 +2,7 @@ import { createServer, Server as HttpServer } from 'http';
 import { Server } from 'socket.io';
 import { io, Socket } from 'socket.io-client';
 import { SocketControllers } from '../../src/SocketControllers';
-import { Container, ContainerInstance, Inject, Service, Token } from "typedi";
+import { Container, ContainerInstance, Inject, Service, Token } from 'typedi';
 import { SocketController } from '../../src/decorators/SocketController';
 import { OnConnect } from '../../src/decorators/OnConnect';
 import { ConnectedSocket } from '../../src/decorators/ConnectedSocket';
@@ -241,8 +241,8 @@ describe('Scoped controllers', () => {
         return container;
       },
       scopedContainerDisposer: (scopedContainer: ContainerInstance) => {
-        scopedContainer.reset({strategy: 'resetServices'});
-      }
+        scopedContainer.reset({ strategy: 'resetServices' });
+      },
     });
     wsClient = io(PATH_FOR_CLIENT + '/string', { reconnection: false, timeout: 5000, forceNew: true });
 

--- a/test/functional/scoped-controllers.spec.ts
+++ b/test/functional/scoped-controllers.spec.ts
@@ -2,7 +2,7 @@ import { createServer, Server as HttpServer } from 'http';
 import { Server } from 'socket.io';
 import { io, Socket } from 'socket.io-client';
 import { SocketControllers } from '../../src/SocketControllers';
-import { Container, Inject, Service, Token } from 'typedi';
+import { Container, ContainerInstance, Inject, Service, Token } from "typedi";
 import { SocketController } from '../../src/decorators/SocketController';
 import { OnConnect } from '../../src/decorators/OnConnect';
 import { ConnectedSocket } from '../../src/decorators/ConnectedSocket';
@@ -205,5 +205,53 @@ describe('Scoped controllers', () => {
     expect(testResult[1].eventName).toBe('test');
     expect(testResult[1].messageArgs).toEqual(['args1']);
     expect(testResult[1].nspParams).toEqual({ test: 'string' });
+  });
+
+  it('container should be disposed', async () => {
+    const token = new Token('ADDITIONAL');
+
+    @Service({ global: true })
+    class TestService {}
+
+    @SocketController('/string')
+    @Service()
+    class TestController {
+      constructor(private testService: TestService, @Inject(token) public myAdditional: number) {}
+
+      @OnConnect()
+      connected(@ConnectedSocket() socket: Socket) {
+        socket.emit('connected');
+      }
+
+      @OnMessage('test')
+      @EmitOnSuccess('done')
+      test() {
+        testResult.push(this.myAdditional);
+      }
+    }
+
+    let container;
+    socketControllers = new SocketControllers({
+      io: wsApp,
+      container: Container,
+      controllers: [TestController],
+      scopedContainerGetter: () => {
+        container = Container.of('test');
+        container.set(token, 'test');
+        return container;
+      },
+      scopedContainerDisposer: (scopedContainer: ContainerInstance) => {
+        scopedContainer.reset({strategy: 'resetServices'});
+      }
+    });
+    wsClient = io(PATH_FOR_CLIENT + '/string', { reconnection: false, timeout: 5000, forceNew: true });
+
+    await waitForEvent(wsClient, 'connected');
+    wsClient.emit('test');
+    await waitForEvent(wsClient, 'done');
+
+    expect(Container.has(TestService)).toBe(true);
+    expect(container.has(token)).toBe(false);
+    expect(container.has(TestController)).toBe(false);
   });
 });


### PR DESCRIPTION
## Description
Add `scopedContainerDisposer` to `SocketControllersOptions` to be able to dispose scoped containers after the action is finished

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #553
